### PR TITLE
fix(schema): align Review schema with Schema 2.0 mapping

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,19 @@
 # Change log
 
+## [2.2] - 2026-07-29
+
+### Fixed
+- Schema: replaced duplicate `itemReviewed` keys (tour + accommodation were silently overwriting each other) with a new `add_items_reviewed()` method that merges both into a single array.
+- Schema: `ratingValue` is now cast to `(int)` to match Schema.org convention; `bestRating` is fixed at `5` and `worstRating` at `1`; the `reviewRating` block is now conditional on a non-empty rating value.
+- Schema: review `@id` updated from `#review` to `#/schema/review/{id}` to avoid collisions on pages with multiple reviews.
+- Schema: `email` removed from the nested `author` `Person` object to prevent exposure of reviewer contact data.
+- Schema: `taxonomy` field mapped from `reviewSection` → `about` for `category` terms.
+- Schema: description now uses `\lsx\schema\Helpers::strip_to_text()` on filtered content instead of a bare `wp_strip_all_tags()` call.
+- Schema: date-of-visit range now formatted as an ISO 8601 interval (`start/end`) using `\lsx\schema\Helpers::format_iso_date()`; falls back to an `additionalProperty` `PropertyValue` when only one date is present.
+- Schema: destinations typed as `TouristDestination` (was Country/State based on post parent check); tours typed as `TouristTrip`; accommodation typed as `LodgingBusiness`.
+- Schema: replaced `get_the_ID()` calls with explicit `$post->ID` for consistency in meta queries.
+- Schema: added `url` property to the root Review node.
+
 ## [[2.1]](https://github.com/lightspeeddevelopment/to-reviews/releases/tag/2.1) - 2025-12-20
 
 ### Description

--- a/classes/class-to-review-schema.php
+++ b/classes/class-to-review-schema.php
@@ -32,62 +32,115 @@ class LSX_TO_Schema_Review extends LSX_TO_Schema_Graph_Piece {
 		$review_author       = get_post_meta( $post->ID, 'reviewer_name', true );
 		$review_email        = get_post_meta( $post->ID, 'reviewer_email', true );
 		$rating_value        = get_post_meta( $post->ID, 'rating', true );
-		$description         = wp_strip_all_tags( get_the_content() );
-		$tour_list           = get_post_meta( get_the_ID(), 'tour_to_review', false );
-		$accom_list          = get_post_meta( get_the_ID(), 'accommodation_to_review', false );
+		$description         = wp_strip_all_tags( apply_filters( 'the_content', $post->post_content ) );
+		$tour_list           = get_post_meta( $post->ID, 'tour_to_review', false );
+		$accom_list          = get_post_meta( $post->ID, 'accommodation_to_review', false );
 		$comment_count       = get_comment_count( $this->context->id );
-		$review_author       = get_post_meta( $post->ID, 'reviewer_name', true );
 		$date_of_visit_start = get_post_meta( $post->ID, 'date_of_visit_start', true );
 		$date_of_visit_end   = get_post_meta( $post->ID, 'date_of_visit_end', true );
 
-		$data          = array(
+		$data = array(
 			'@type'            => 'Review',
-			'@id'              => $this->context->canonical . '#review',
+			'@id'              => $this->context->canonical . '#/schema/review/' . $post->ID,
+			'url'              => $this->post_url,
 			'author'           => array(
 				'@type' => 'Person',
 				'@id'   => \lsx\legacy\Schema_Utils::get_author_schema_id( $review_author, $review_email, $this->context ),
 				'name'  => $review_author,
-				'email' => $review_email,
 			),
-			'headline'         => get_the_title(),
+			'headline'         => get_the_title( $post->ID ),
 			'datePublished'    => mysql2date( DATE_W3C, $post->post_date_gmt, false ),
 			'dateModified'     => mysql2date( DATE_W3C, $post->post_modified_gmt, false ),
 			'commentCount'     => $comment_count['approved'],
 			'mainEntityOfPage' => array(
 				'@id' => $this->context->canonical . WPSEO_Schema_IDs::WEBPAGE_HASH,
 			),
-			'reviewRating' => array(
+			'reviewBody'       => $description,
+		);
+
+		if ( false !== $rating_value && '' !== $rating_value ) {
+			$data['reviewRating'] = array(
 				'@type'       => 'Rating',
 				'ratingValue' => $rating_value,
-				'bestRating'  => $rating_value,
-			),
-			'reviewBody'       => $description,
-			'itemReviewed'     => \lsx\legacy\Schema_Utils::get_item_reviewed( $tour_list, 'Product' ),
-			'itemReviewed'     => \lsx\legacy\Schema_Utils::get_item_reviewed( $accom_list, 'Product' ),
-		);
+				'bestRating'  => '5',
+				'worstRating' => '1',
+			);
+		}
+
+		$data = $this->add_items_reviewed( $data, $tour_list, $accom_list );
 
 		if ( $this->context->site_represents_reference ) {
 			$data['publisher'] = $this->context->site_represents_reference;
 		}
 
-		if ( '' !== $date_of_visit_start && '' !== $date_of_visit_end ) {
-			$data['temporalCoverage'] = $date_of_visit_start . ' - ' . $date_of_visit_end;
-		}
+		$data = $this->add_date_of_visit( $data, $date_of_visit_start, $date_of_visit_end );
 
 		$data = \lsx\legacy\Schema_Utils::add_image( $data, $this->context );
 		$data = $this->add_taxonomy_terms( $data, 'keywords', 'post_tag' );
-		$data = $this->add_taxonomy_terms( $data, 'reviewSection', 'category' );
+		$data = $this->add_taxonomy_terms( $data, 'about', 'category' );
 		$data = $this->add_offers( $data );
 		$data = $this->add_destinations( $data );
 		return $data;
 	}
 
 	/**
-	 * Adds the Destinations attached to the review
+	 * Merges the related tour and accommodation posts into a single
+	 * itemReviewed value, typed appropriately, without overwriting each other.
 	 *
-	 * @param array $data Country / State data.
+	 * @param array $data       Review data.
+	 * @param array $tour_list  Related tour post IDs.
+	 * @param array $accom_list Related accommodation post IDs.
+	 * @return array $data Review data.
+	 */
+	public function add_items_reviewed( $data, $tour_list, $accom_list ) {
+		$items_reviewed = array();
+		$items_reviewed = array_merge( $items_reviewed, \lsx\legacy\Schema_Utils::get_item_reviewed( $tour_list, 'TouristTrip' ) );
+		$items_reviewed = array_merge( $items_reviewed, \lsx\legacy\Schema_Utils::get_item_reviewed( $accom_list, 'LodgingBusiness' ) );
+
+		if ( ! empty( $items_reviewed ) ) {
+			$data['itemReviewed'] = 1 === count( $items_reviewed ) ? $items_reviewed[0] : $items_reviewed;
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Adds the date of visit as an ISO 8601 temporalCoverage interval when both
+	 * dates are available, falling back to an additionalProperty otherwise.
 	 *
-	 * @return array $data Country / State data.
+	 * @param array  $data                Review data.
+	 * @param string $date_of_visit_start Start of visit timestamp.
+	 * @param string $date_of_visit_end   End of visit timestamp.
+	 * @return array $data Review data.
+	 */
+	public function add_date_of_visit( $data, $date_of_visit_start, $date_of_visit_end ) {
+		if ( '' === $date_of_visit_start && '' === $date_of_visit_end ) {
+			return $data;
+		}
+
+		$start = is_numeric( $date_of_visit_start ) ? gmdate( 'Y-m-d', (int) $date_of_visit_start ) : '';
+		$end   = is_numeric( $date_of_visit_end ) ? gmdate( 'Y-m-d', (int) $date_of_visit_end ) : '';
+
+		if ( '' !== $start && '' !== $end ) {
+			$data['temporalCoverage'] = $start . '/' . $end;
+		} else {
+			$data['additionalProperty'][] = array(
+				'@type' => 'PropertyValue',
+				'name'  => __( 'Date of Visit', 'to-reviews' ),
+				'value' => trim( $start . ' ' . $end ),
+			);
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Adds the Destinations attached to the review as spatialCoverage,
+	 * typed as TouristDestination.
+	 *
+	 * @param array $data Review data.
+	 *
+	 * @return array $data Review data.
 	 */
 	public function add_destinations( $data, $data_key = '' ) {
 		$places_array = array();
@@ -95,11 +148,7 @@ class LSX_TO_Schema_Review extends LSX_TO_Schema_Graph_Piece {
 		if ( ! empty( $destinations ) ) {
 			foreach ( $destinations as $destination_id ) {
 				if ( '' !== $destination_id ) {
-					if ( 0 === wp_get_post_parent_id( $destination_id ) || false === wp_get_post_parent_id( $destination_id ) ) {
-						$places_array = \lsx\legacy\Schema_Utils::add_place( $places_array, 'Country', $destination_id, $this->context );
-					} else {
-						$places_array = \lsx\legacy\Schema_Utils::add_place( $places_array, 'State', $destination_id, $this->context );
-					}
+					$places_array = \lsx\legacy\Schema_Utils::add_place( $places_array, 'TouristDestination', $destination_id, $this->context );
 				}
 			}
 		}

--- a/classes/class-to-review-schema.php
+++ b/classes/class-to-review-schema.php
@@ -61,9 +61,9 @@ class LSX_TO_Schema_Review extends LSX_TO_Schema_Graph_Piece {
 		if ( false !== $rating_value && '' !== $rating_value ) {
 			$data['reviewRating'] = array(
 				'@type'       => 'Rating',
-				'ratingValue' => $rating_value,
-				'bestRating'  => '5',
-				'worstRating' => '1',
+				'ratingValue' => (int) $rating_value,
+				'bestRating'  => 5,
+				'worstRating' => 1,
 			);
 		}
 

--- a/classes/class-to-review-schema.php
+++ b/classes/class-to-review-schema.php
@@ -32,7 +32,7 @@ class LSX_TO_Schema_Review extends LSX_TO_Schema_Graph_Piece {
 		$review_author       = get_post_meta( $post->ID, 'reviewer_name', true );
 		$review_email        = get_post_meta( $post->ID, 'reviewer_email', true );
 		$rating_value        = get_post_meta( $post->ID, 'rating', true );
-		$description         = wp_strip_all_tags( apply_filters( 'the_content', $post->post_content ) );
+		$description         = \lsx\schema\Helpers::strip_to_text( apply_filters( 'the_content', $post->post_content ) );
 		$tour_list           = get_post_meta( $post->ID, 'tour_to_review', false );
 		$accom_list          = get_post_meta( $post->ID, 'accommodation_to_review', false );
 		$comment_count       = get_comment_count( $this->context->id );
@@ -118,8 +118,8 @@ class LSX_TO_Schema_Review extends LSX_TO_Schema_Graph_Piece {
 			return $data;
 		}
 
-		$start = is_numeric( $date_of_visit_start ) ? gmdate( 'Y-m-d', (int) $date_of_visit_start ) : '';
-		$end   = is_numeric( $date_of_visit_end ) ? gmdate( 'Y-m-d', (int) $date_of_visit_end ) : '';
+		$start = \lsx\schema\Helpers::format_iso_date( $date_of_visit_start );
+		$end   = \lsx\schema\Helpers::format_iso_date( $date_of_visit_end );
 
 		if ( '' !== $start && '' !== $end ) {
 			$data['temporalCoverage'] = $start . '/' . $end;


### PR DESCRIPTION
## Summary

Aligns `class-to-review-schema.php` with the approved Schema 2.0 mapping and shared helpers.

## Changes

### Fixed
- **Duplicate `itemReviewed` keys** — tours and accommodation were silently overwriting each other. Replaced with a new `add_items_reviewed()` method that merges both into a single value (scalar when one item, array when many).
- **`ratingValue` type** — cast to `(int)` to match Schema.org convention. `bestRating` fixed at `5`, `worstRating` at `1`. The whole `reviewRating` block is now conditional on a non-empty rating value.
- **`@id` collision** — changed from `#review` to `#/schema/review/{id}` to avoid conflicts when multiple reviews appear on one page.
- **Author `email` exposure** — removed `email` from the nested `Person` object.
- **Taxonomy field** — `reviewSection` → `about` for `category` terms.
- **Description** — now uses `\lsx\schema\Helpers::strip_to_text()` on `apply_filters('the_content', ...)` instead of a bare `wp_strip_all_tags()`.
- **Date of visit** — formatted as an ISO 8601 interval (`start/end`) via `\lsx\schema\Helpers::format_iso_date()`; falls back to an `additionalProperty` `PropertyValue` when only one date is present.
- **Item types** — destinations typed as `TouristDestination` (was Country/State based on post-parent check); tours as `TouristTrip`; accommodation as `LodgingBusiness`.
- **Meta queries** — replaced `get_the_ID()` calls with explicit `$post->ID`.
- **`url` property** — added to the root Review node.

## Testing

- [ ] Review with tour and accommodation attached — confirm single `itemReviewed` merges both.
- [ ] Review with no rating — confirm `reviewRating` is absent from output.
- [ ] Review with only a start date — confirm `additionalProperty` fallback appears.
- [ ] Review with both dates — confirm `temporalCoverage` is a valid ISO 8601 interval.
- [ ] Destination schema — confirm type is `TouristDestination` regardless of hierarchy.
- [ ] Validate output with Google Rich Results Test or Schema.org validator.

## Checklist

- [x] Changelog updated
- [x] No new dependencies introduced
- [x] Follows `\lsx\schema\Helpers` shared helper conventions