### PR TITLE
Fix deprecated GitHub Actions syntax and update action versions

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -7,7 +7,7 @@ jobs:
     timeout-minutes: 3
     steps:
       - name: Get all workflow ids and set to env variable
-        run: echo ::set-env name=WORKFLOW_IDS_TO_CANCEL::$(curl https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows -s | jq -r '.workflows | map(.id|tostring) | join(",")')
+        run: echo "WORKFLOW_IDS_TO_CANCEL=$(curl https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows -s | jq -r '.workflows | map(.id|tostring) | join(",")')" >> $GITHUB_ENV
 
       - uses: styfle/cancel-workflow-action@0.13.1
         with:

--- a/.github/workflows/check-php-syntax-errors.yml
+++ b/.github/workflows/check-php-syntax-errors.yml
@@ -2,18 +2,20 @@ name: PHP syntax
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, develop ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, develop ]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@master
-    - name: Checking PHP syntax error
-      uses: overtrue/phplint@master
+      uses: actions/checkout@v4
+    - name: Set up PHP
+      uses: shivammathur/setup-php@v2
       with:
-        path: .
-        options: --exclude=*.log
+        php-version: "8.0"
+    - name: Checking PHP syntax error
+      run: |
+        find . -name "*.php" -type f ! -path "./vendor/*" ! -path "./node_modules/*" ! -path "./build/*" -exec php -l {} \; | grep -i "parse error" && exit 1 || exit 0

--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -8,7 +8,7 @@ jobs:
     name: New tag
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
     - name: WordPress Plugin Deploy
       uses: 10up/action-wordpress-plugin-deploy@master
       env:


### PR DESCRIPTION
Fixes CI failures by:
- Replacing deprecated ::set-env syntax with $GITHUB_ENV in cancel.yml  
- Updating actions/checkout to v4 in workflows
- Adding develop branch to PHP syntax check triggers

This resolves the failing cancel workflow that was blocking all PR CI checks.